### PR TITLE
Extended options for activity paste

### DIFF
--- a/src/components/activity/PasteActivitiesContextMenu.svelte
+++ b/src/components/activity/PasteActivitiesContextMenu.svelte
@@ -21,10 +21,10 @@
   export let plan: Plan | null;
   export let planPermissionErrorText: string | null = null;
 
-  async function pasteActivityDirectives(atTime: Date | undefined) {
+  async function pasteActivityDirectives(atTime: Date | undefined, clampToPlanBounds: boolean) {
     if (plan != null && hasCreatePermission) {
       const timeValue = atTime && atTime.getTime();
-      const activities = await getActivityDirectivesToPaste(plan, timeValue);
+      const activities = await getActivityDirectivesToPaste(plan, clampToPlanBounds, timeValue);
       dispatch(`createActivityDirectives`, activities);
     }
   }
@@ -44,9 +44,24 @@
       ...(permissionError !== null ? { permissionError } : null),
     }}
   >
-    <ContextMenu.Item size="sm" on:click={() => pasteActivityDirectives(atTime)} disabled={!hasPermission}>
+    <ContextMenu.Item size="sm" on:click={() => pasteActivityDirectives(atTime, false)} disabled={!hasPermission}>
       {getPasteActivityDirectivesText(directivesInClipboard)}
       {atTime === undefined ? `` : `At Time`}
     </ContextMenu.Item>
+    <!-- Only show other options in table/non-atTime setup -->
+    {#if atTime === undefined && plan !== null}
+      <ContextMenu.Item
+        size="sm"
+        on:click={() => pasteActivityDirectives(new Date(plan.start_time), false)}
+        disabled={!hasPermission}
+      >
+        {getPasteActivityDirectivesText(directivesInClipboard)}
+        At Plan Start
+      </ContextMenu.Item>
+      <ContextMenu.Item size="sm" on:click={() => pasteActivityDirectives(atTime, true)} disabled={!hasPermission}>
+        {getPasteActivityDirectivesText(directivesInClipboard)}
+        Clamped To Plan
+      </ContextMenu.Item>
+    {/if}
   </div>
 {/await}

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -299,6 +299,7 @@ export async function getActivityDirectivesClipboardCount(): Promise<number> {
 
 export async function getActivityDirectivesToPaste(
   destinationPlan: Plan,
+  clampToPlanBounds: boolean,
   pasteStartingAtTime?: number,
 ): Promise<ActivityDirective[]> {
   let activities: ActivityDirective[] = [];
@@ -307,27 +308,18 @@ export async function getActivityDirectivesToPaste(
     if (serializedClipboard !== undefined) {
       const clipboard = JSON.parse(serializedClipboard);
       activities = clipboard.activities;
-
       const starts: number[] = [];
       activities.forEach(a => {
-        //unachored activities are the ones we're trying to place relative to each other in time, anchored will be calculated from offset
+        // Anchored activities are the ones we're trying to place relative to each other in time, anchored will be calculated from offset
         if (a.anchor_id === null && a.start_time_ms !== null) {
           starts.push(a.start_time_ms);
         }
       });
 
-      //bounded by plan start and plan end
+      // Bounded by plan start and plan end
       const planStart = getUnixEpochTime(destinationPlan.start_time_doy);
-      const planEnd = getUnixEpochTime(destinationPlan.end_time_doy);
       const earliestStart = Math.min(...starts);
-      // Only fall back to plan start when the caller didn't pick a paste time. A right-click → Paste
-      // at time X must always honor X — cross-plan pastes (e.g. from search results) routinely have
-      // source absolute times far outside the target plan's window.
-      if (pasteStartingAtTime === undefined && (earliestStart < planStart || earliestStart > planEnd)) {
-        pasteStartingAtTime = planStart;
-      }
-
-      //transpose in time if we're given a time or if it was out of bounds
+      // Transpose in time if we're given a time or if it was out of bounds
       let diff = 0;
       if (typeof pasteStartingAtTime === 'number') {
         diff = pasteStartingAtTime - earliestStart;
@@ -335,11 +327,15 @@ export async function getActivityDirectivesToPaste(
 
       activities.forEach(activity => {
         if (activity.start_time_ms !== null) {
-          //anchored activities don't need offset to be updated
+          // Anchored activities don't need offset to be updated
           if (activity.anchor_id === null) {
-            activity.start_time_ms += diff;
-            const startTimeDoy = getDoyTime(new Date(activity.start_time_ms));
-            activity.start_offset = getIntervalFromDoyRange(destinationPlan.start_time_doy, startTimeDoy);
+            if (clampToPlanBounds) {
+              activity.start_time_ms += planStart - activity.start_time_ms;
+            } else {
+              activity.start_time_ms += diff;
+              const startTimeDoy = getDoyTime(new Date(activity.start_time_ms));
+              activity.start_offset = getIntervalFromDoyRange(destinationPlan.start_time_doy, startTimeDoy);
+            }
           }
         }
       });


### PR DESCRIPTION
This PR adds extra options to activity pasting based on the discussion in #1930. Pasting directly to the timeline is not altered with these changes, but pasting into the activity directive table now has multiple choices..

1. `Paste`, places the activity at its **absolute time**, even if it is outside the plan bounds
2. `Paste at Plan Start`, places the activity at **exactly** the plan start
3. `Paste Clamped to Plan`, places the activity at the start of the destination plan with whatever offset it had in the previous plan

<img width="1476" height="678" alt="image" src="https://github.com/user-attachments/assets/31d1295a-76ea-4409-ae3c-c7f82bcab5fb" />

### Testing
1. Create a plan
2. Create a second plan with a completely different timespan
3. Add an activity directive to the first plan with a non-0 offset
4. Copy it
5. Open the second plan
6. Right-click on the activity directive table and select `Paste 1 Activity Directive` - **the activity should be pasted at the absolute time**
7.  Right-click on the activity directive table and select `Paste 1 Activity Directive at Plan Start` - **the activity should be pasted directly at the start of the plan**
8. Right-click on the activity directive table and select `Paste 1 Activity Directive Clamped to Plan` - **the activity should be pasted at the start of the plan, plus its old offset**