### PR TITLE
Prevent duplicate goal invocations from repeated Update clicks in Manage Scheduling Goals modal

### DIFF
--- a/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
@@ -106,6 +106,7 @@
   let hasCreatePermission: boolean = false;
   let hasEditSpecPermission: boolean = false;
   let selectedGoals: Record<string, boolean> = {};
+  let updatingGoals: boolean = false;
 
   $: filteredGoals = $schedulingGoals
     // TODO: remove this after db merge as it becomes redundant
@@ -207,6 +208,9 @@
   }
 
   async function onUpdateGoals(selectedGoals: Record<number, boolean>) {
+    if (updatingGoals) {
+      return;
+    }
     if ($plan && $schedulingPlanSpecification) {
       const goalPlanSpecUpdates: {
         goalPlanSpecIdsToDelete: number[];
@@ -259,12 +263,14 @@
           goalPlanSpecsToAdd: [],
         },
       );
+      updatingGoals = true;
       await effects.updateSchedulingGoalPlanSpecifications(
         $plan,
         goalPlanSpecUpdates.goalPlanSpecsToAdd,
         goalPlanSpecUpdates.goalPlanSpecIdsToDelete,
         user,
       );
+      updatingGoals = false;
       dispatch('close');
     }
   }
@@ -308,6 +314,7 @@
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
     <button
       class="st-button"
+      disabled={updatingGoals}
       on:click={() => onUpdateGoals(selectedGoals)}
       use:permissionHandler={{
         hasPermission: hasEditSpecPermission && !$planReadOnly,

--- a/src/components/modals/ManagePlanSchedulingGoalsModal.svelte.test.ts
+++ b/src/components/modals/ManagePlanSchedulingGoalsModal.svelte.test.ts
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { writable } from 'svelte/store';
+import ManagePlanSchedulingGoalsModal from './ManagePlanSchedulingGoalsModal.svelte';
+
+vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
+vi.mock('$app/paths', () => ({ base: '' }));
+
+vi.mock('../../utilities/effects', () => ({
+  default: {
+    updateSchedulingGoalPlanSpecifications: vi.fn(),
+  },
+}));
+
+vi.mock('../../utilities/permissionHandler', () => ({
+  permissionHandler: () => ({ destroy: () => undefined, update: () => undefined }),
+}));
+
+vi.mock('../../utilities/permissions', () => ({
+  featurePermissions: {
+    schedulingGoals: { canCreate: () => true },
+    schedulingGoalsPlanSpec: { canUpdate: () => true },
+  },
+  isAdminRole: () => true,
+}));
+
+vi.mock('../../stores/plan', () => ({
+  plan: writable({ id: 1, model: { id: 1 }, model_id: 1, name: 'test-plan' }),
+  planReadOnly: writable(false),
+}));
+
+vi.mock('../../stores/scheduling', () => ({
+  allowedSchedulingGoalSpecs: writable([]),
+  schedulingGoals: writable([]),
+  schedulingGoalsLoading: writable(false),
+  schedulingPlanSpecification: writable({ id: 1 }),
+}));
+
+vi.stubGlobal(
+  'ResizeObserver',
+  vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  })),
+);
+
+describe('ManagePlanSchedulingGoalsModal', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('Should send a single update request when "Update" is clicked once', async () => {
+    const effects = (await import('../../utilities/effects')).default;
+    vi.mocked(effects.updateSchedulingGoalPlanSpecifications).mockResolvedValue(undefined);
+
+    const { getByRole } = render(ManagePlanSchedulingGoalsModal, { user: null });
+    const updateButton = getByRole('button', { name: 'Update' });
+
+    await fireEvent.click(updateButton);
+
+    await waitFor(() => expect(effects.updateSchedulingGoalPlanSpecifications).toHaveBeenCalledTimes(1));
+  });
+
+  it('Should not send a second update request when "Update" is clicked again while a request is in flight', async () => {
+    const effects = (await import('../../utilities/effects')).default;
+    // Hold the first request open so the second click happens while it is still in flight,
+    // which is the race that produced duplicate goal invocations (#1974). The guard under
+    // test is the in-flight check itself, so the request payload is irrelevant here.
+    let resolveUpdate: (value?: PromiseLike<void> | void) => void = () => undefined;
+    vi.mocked(effects.updateSchedulingGoalPlanSpecifications).mockImplementation(
+      () => new Promise<void>(resolve => (resolveUpdate = resolve)),
+    );
+
+    const { getByRole } = render(ManagePlanSchedulingGoalsModal, { user: null });
+    const updateButton = getByRole('button', { name: 'Update' }) as HTMLButtonElement;
+
+    await fireEvent.click(updateButton);
+    await fireEvent.click(updateButton);
+
+    // On unpatched code this reports 2 calls — the duplicate request that produces duplicate invocations.
+    expect(effects.updateSchedulingGoalPlanSpecifications).toHaveBeenCalledTimes(1);
+    expect(updateButton.disabled).toBe(true);
+
+    resolveUpdate();
+
+    await waitFor(() => expect(effects.updateSchedulingGoalPlanSpecifications).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
### Fixes #1974

Adds an in-flight guard to the Manage Scheduling Goals modal: an updatingGoals flag disables the Update button and short-circuits onUpdateGoals while effects.updateSchedulingGoalPlanSpecifications is in flight, so repeated clicks can no longer insert duplicate goal invocations. Follows the existing inFlight pattern in ChangePlanBoundsModal.

Includes a component test that holds the first update request open and clicks Update twice: on unpatched code it fails with two requests sent; with the guard it passes with one. svelte-check, ESLint, Prettier, and the full unit suite (871 tests) are clean.

Scoped deliberately to this modal per the issue — ManagePlanSchedulingConditionsModal and ManagePlanConstraintsModal share the same pattern and would make a good follow-up.