### PR TITLE
Improve performance on derivation group subscription

### DIFF
--- a/e2e-tests/tests/plan-external-source.test.ts
+++ b/e2e-tests/tests/plan-external-source.test.ts
@@ -209,9 +209,9 @@ test.describe.serial('Plan External Sources', () => {
       setup.page.locator('#svelte-modal').getByText('Key: ExampleExternalSource:example-external-source.json'),
     ).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Source Type: Example External Source')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-01-01T00:00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-01-02T00:00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-01-01T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-001T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-002T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-001T00:00:00')).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Created At')).toBeVisible();
   });
 });

--- a/e2e-tests/tests/plan-external-source.test.ts
+++ b/e2e-tests/tests/plan-external-source.test.ts
@@ -1,7 +1,6 @@
 import test, { expect } from '@playwright/test';
 import { ExternalSources } from '../fixtures/ExternalSources.js';
 import { PanelNames, Plan } from '../fixtures/Plan.js';
-import { anyCanvasHasContent } from '../utilities/canvas.js';
 import {
   cleanupApiResources,
   closeBrowserResources,
@@ -10,6 +9,7 @@ import {
   type BrowserSetupResult,
   type FullSetupResult,
 } from '../utilities/api.js';
+import { anyCanvasHasContent } from '../utilities/canvas.js';
 
 // Main setup with model/plan (uses 'test' user for API operations)
 let setup: FullSetupResult;
@@ -188,9 +188,9 @@ test.describe.serial('Plan External Sources', () => {
 
     await expect(setup.page.getByText('Key: ExampleExternalSource:')).toBeVisible();
     await expect(setup.page.getByText('Source Type: Example External')).toBeVisible();
-    await expect(setup.page.getByText('Start Time: 2022-001T00:00:')).toBeVisible();
-    await expect(setup.page.getByText('End Time: 2022-002T00:00:')).toBeVisible();
-    await expect(setup.page.getByText('Valid At: 2022-001T00:00:')).toBeVisible();
+    await expect(setup.page.getByText('Start Time: 2022-01-01T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.getByText('End Time: 2022-01-02T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.getByText('Valid At: 2022-01-01T00:00:00+00:00')).toBeVisible();
     await expect(setup.page.getByText('Created At')).toBeVisible();
   });
 
@@ -209,9 +209,9 @@ test.describe.serial('Plan External Sources', () => {
       setup.page.locator('#svelte-modal').getByText('Key: ExampleExternalSource:example-external-source.json'),
     ).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Source Type: Example External Source')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-001T00:00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-002T00:00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-001T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-01-01T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-01-02T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-01-01T00:00:00+00:00')).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Created At')).toBeVisible();
   });
 });

--- a/e2e-tests/tests/plan-external-source.test.ts
+++ b/e2e-tests/tests/plan-external-source.test.ts
@@ -188,9 +188,9 @@ test.describe.serial('Plan External Sources', () => {
 
     await expect(setup.page.getByText('Key: ExampleExternalSource:')).toBeVisible();
     await expect(setup.page.getByText('Source Type: Example External')).toBeVisible();
-    await expect(setup.page.getByText('Start Time: 2022-01-01T00:00:00+00:00')).toBeVisible();
-    await expect(setup.page.getByText('End Time: 2022-01-02T00:00:00+00:00')).toBeVisible();
-    await expect(setup.page.getByText('Valid At: 2022-01-01T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.getByText('Start Time: 2022-01-01T00:00:00')).toBeVisible();
+    await expect(setup.page.getByText('End Time: 2022-01-02T00:00:00')).toBeVisible();
+    await expect(setup.page.getByText('Valid At: 2022-01-01T00:00:00')).toBeVisible();
     await expect(setup.page.getByText('Created At')).toBeVisible();
   });
 
@@ -209,9 +209,9 @@ test.describe.serial('Plan External Sources', () => {
       setup.page.locator('#svelte-modal').getByText('Key: ExampleExternalSource:example-external-source.json'),
     ).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Source Type: Example External Source')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-01-01T00:00:00+00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-01-02T00:00:00+00:00')).toBeVisible();
-    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-01-01T00:00:00+00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Start Time: 2022-01-01T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('End Time: 2022-01-02T00:00:00')).toBeVisible();
+    await expect(setup.page.locator('#svelte-modal').getByText('Valid At: 2022-01-01T00:00:00')).toBeVisible();
     await expect(setup.page.locator('#svelte-modal').getByText('Created At')).toBeVisible();
   });
 });

--- a/e2e-tests/tests/plan-external-source.test.ts
+++ b/e2e-tests/tests/plan-external-source.test.ts
@@ -158,7 +158,9 @@ test.describe.serial('Plan External Sources', () => {
   });
 
   test('Zero-duration events are properly drawn in the timeline', async () => {
-    expect(await anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas')).toBeTruthy();
+    await expect
+      .poll(() => anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas'), { timeout: 10000 })
+      .toBe(true);
   });
 
   test('Linked derivation groups should be expandable in panel', async () => {
@@ -188,9 +190,9 @@ test.describe.serial('Plan External Sources', () => {
 
     await expect(setup.page.getByText('Key: ExampleExternalSource:')).toBeVisible();
     await expect(setup.page.getByText('Source Type: Example External')).toBeVisible();
-    await expect(setup.page.getByText('Start Time: 2022-01-01T00:00:00')).toBeVisible();
-    await expect(setup.page.getByText('End Time: 2022-01-02T00:00:00')).toBeVisible();
-    await expect(setup.page.getByText('Valid At: 2022-01-01T00:00:00')).toBeVisible();
+    await expect(setup.page.getByText('Start Time: 2022-001T00:00:00')).toBeVisible();
+    await expect(setup.page.getByText('End Time: 2022-002T00:00:00')).toBeVisible();
+    await expect(setup.page.getByText('Valid At: 2022-001T00:00:00')).toBeVisible();
     await expect(setup.page.getByText('Created At')).toBeVisible();
   });
 

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -9,12 +9,14 @@
   export let source: ExternalSourceSlim;
   export let user: User | null = null;
 
+  let isExpanded = false;
+  let hasFetched = false;
   let sourceEvents: number | null = null;
 
-  $: effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount));
+  $: if (isExpanded && !hasFetched) { hasFetched = true; effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount)) };
 </script>
 
-<Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
+<Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false} on:collapse={e => (isExpanded = !e.detail)}>
   <svelte:fragment slot="right">
     <p class="st-typography-body derived-event-count">
       {#if sourceEvents !== null}

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { plugins } from '../../stores/plugins';
   import type { User } from '../../types/app';
   import type { ExternalSourceSlim } from '../../types/external-source';
   import effects from '../../utilities/effects';
+  import { formatDate } from '../../utilities/time';
   import Collapse from '../Collapse.svelte';
 
   export let source: ExternalSourceSlim;
@@ -30,21 +32,21 @@
 
   <div class="st-typography-body">
     <div class="st-typography-bold">Start Time:</div>
-    {source.start_time}
+    {formatDate(new Date(source.start_time), $plugins.time.primary.format)}
   </div>
 
   <div class="st-typography-body">
     <div class="st-typography-bold">End Time:</div>
-    {source.end_time}
+    {formatDate(new Date(source.end_time), $plugins.time.primary.format)}
   </div>
 
   <div class="st-typography-body">
     <div class="st-typography-bold">Valid At:</div>
-    {source.valid_at}
+    {formatDate(new Date(source.valid_at), $plugins.time.primary.format)}
   </div>
 
   <div class="st-typography-body">
     <div class="st-typography-bold">Created At:</div>
-    {source.created_at}
+    {formatDate(new Date(source.created_at), $plugins.time.primary.format)}
   </div>
 </Collapse>

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -59,6 +59,6 @@
 
   <div class="st-typography-body">
     <div class="st-typography-bold">Created At:</div>
-    {formatDate(new Date(source.created_at), $plugins.time.primary.format)}
+    {new Date(source.created_at).toISOString()}
   </div>
 </Collapse>

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { User } from '../../types/app';
+  import type { ExternalSourceSlim } from '../../types/external-source';
+  import effects from '../../utilities/effects';
+  import Collapse from '../Collapse.svelte';
+
+  export let source: ExternalSourceSlim;
+  export let user: User | null = null;
+
+  let sourceEvents: number = 0;
+
+  $: effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount));
+</script>
+
+<Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
+  <svelte:fragment slot="right">
+    <p class="st-typography-body derived-event-count">
+      {sourceEvents} events
+    </p>
+  </svelte:fragment>
+  <div class="st-typography-body">
+    <div class="st-typography-bold">Key:</div>
+    {source.key}
+  </div>
+
+  <div class="st-typography-body">
+    <div class="st-typography-bold">Source Type:</div>
+    {source.source_type_name}
+  </div>
+
+  <div class="st-typography-body">
+    <div class="st-typography-bold">Start Time:</div>
+    {source.start_time}
+  </div>
+
+  <div class="st-typography-body">
+    <div class="st-typography-bold">End Time:</div>
+    {source.end_time}
+  </div>
+
+  <div class="st-typography-body">
+    <div class="st-typography-bold">Valid At:</div>
+    {source.valid_at}
+  </div>
+
+  <div class="st-typography-body">
+    <div class="st-typography-bold">Created At:</div>
+    {source.created_at}
+  </div>
+</Collapse>

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -13,10 +13,18 @@
   let hasFetched = false;
   let sourceEvents: number | null = null;
 
-  $: if (isExpanded && !hasFetched) { hasFetched = true; effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount)) };
+  $: if (isExpanded && !hasFetched) {
+    hasFetched = true;
+    effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount));
+  }
 </script>
 
-<Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false} on:collapse={e => (isExpanded = !e.detail)}>
+<Collapse
+  title={source.key}
+  tooltipContent={source.key}
+  defaultExpanded={false}
+  on:collapse={e => (isExpanded = !e.detail)}
+>
   <svelte:fragment slot="right">
     <p class="st-typography-body derived-event-count">
       {#if sourceEvents !== null}

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -9,7 +9,7 @@
   export let source: ExternalSourceSlim;
   export let user: User | null = null;
 
-  let sourceEvents: number = 0;
+  let sourceEvents: number | null = null;
 
   $: effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount));
 </script>
@@ -17,7 +17,11 @@
 <Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
   <svelte:fragment slot="right">
     <p class="st-typography-body derived-event-count">
-      {sourceEvents} events
+      {#if sourceEvents !== null}
+        {sourceEvents} events
+      {:else}
+        Loading...
+      {/if}
     </p>
   </svelte:fragment>
   <div class="st-typography-body">

--- a/src/components/external-source/ExternalSourceDetails.svelte
+++ b/src/components/external-source/ExternalSourceDetails.svelte
@@ -9,26 +9,24 @@
   export let source: ExternalSourceSlim;
   export let user: User | null = null;
 
-  let isExpanded = false;
   let hasFetched = false;
   let sourceEvents: number | null = null;
 
-  $: if (isExpanded && !hasFetched) {
+  effects.getExternalSourceEventCount(source, user).then(eventCount => {
+    sourceEvents = eventCount;
     hasFetched = true;
-    effects.getExternalSourceEventCount(source, user).then(eventCount => (sourceEvents = eventCount));
-  }
+  });
 </script>
 
-<Collapse
-  title={source.key}
-  tooltipContent={source.key}
-  defaultExpanded={false}
-  on:collapse={e => (isExpanded = !e.detail)}
->
+<Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
   <svelte:fragment slot="right">
-    <p class="st-typography-body derived-event-count">
-      {#if sourceEvents !== null}
-        {sourceEvents} events
+    <p class="st-typography-body derived-event-count whitespace-nowrap">
+      {#if hasFetched}
+        {#if sourceEvents !== null}
+          {sourceEvents} events
+        {:else}
+          <span class="text-red-500">Error fetching event count</span>
+        {/if}
       {:else}
         Loading...
       {/if}

--- a/src/components/external-source/ExternalSourcePanelEntry.svelte
+++ b/src/components/external-source/ExternalSourcePanelEntry.svelte
@@ -5,15 +5,14 @@
   import { get } from 'svelte/store';
   import { derivationGroupVisibilityMap, externalSources } from '../../stores/external-source';
   import { plan } from '../../stores/plan';
-  import { plugins } from '../../stores/plugins';
   import type { User } from '../../types/app';
   import type { DerivationGroup, ExternalSourceSlim } from '../../types/external-source';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { formatDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import Collapse from '../Collapse.svelte';
+  import ExternalSourceDetails from './ExternalSourceDetails.svelte';
 
   export let derivationGroup: DerivationGroup;
   export let user: User | null;
@@ -76,43 +75,7 @@
 
     {#if relevantSources.length}
       {#each relevantSources as source}
-        <!-- Collapsible details -->
-        <Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
-          <svelte:fragment slot="right">
-            <p class="st-typography-body derived-event-count">
-              {derivationGroup.sources.get(source.key)?.event_counts} events
-            </p>
-          </svelte:fragment>
-          <div class="st-typography-body">
-            <div class="st-typography-bold">Key:</div>
-            {source.key}
-          </div>
-
-          <div class="st-typography-body">
-            <div class="st-typography-bold">Source Type:</div>
-            {source.source_type_name}
-          </div>
-
-          <div class="st-typography-body">
-            <div class="st-typography-bold">Start Time:</div>
-            {formatDate(new Date(source.start_time), $plugins.time.primary.format)}
-          </div>
-
-          <div class="st-typography-body">
-            <div class="st-typography-bold">End Time:</div>
-            {formatDate(new Date(source.end_time), $plugins.time.primary.format)}
-          </div>
-
-          <div class="st-typography-body">
-            <div class="st-typography-bold">Valid At:</div>
-            {formatDate(new Date(source.valid_at), $plugins.time.primary.format)}
-          </div>
-
-          <div class="st-typography-body">
-            <div class="st-typography-bold">Created At:</div>
-            {formatDate(new Date(source.created_at), $plugins.time.primary.format)}
-          </div>
-        </Collapse>
+        <ExternalSourceDetails {source} {user} />
       {/each}
     {:else}
       <p class="st-typography-body">No sources in this group.</p>
@@ -138,10 +101,6 @@
     height: 100%;
     padding-right: 0.25rem;
     text-wrap: nowrap;
-  }
-
-  .derived-event-count {
-    color: var(--st-gray-60);
   }
 
   .derivation-group-collapse-details {

--- a/src/components/external-source/ExternalSourcePanelEntry.svelte
+++ b/src/components/external-source/ExternalSourcePanelEntry.svelte
@@ -74,7 +74,7 @@
     </svelte:fragment>
 
     {#if relevantSources.length}
-      {#each relevantSources as source}
+      {#each relevantSources as source (source.key)}
         <ExternalSourceDetails {source} {user} />
       {/each}
     {:else}

--- a/src/components/external-source/ExternalTypeManager.svelte
+++ b/src/components/external-source/ExternalTypeManager.svelte
@@ -54,6 +54,7 @@
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
+  import ExternalSourceDetails from './ExternalSourceDetails.svelte';
 
   export let user: User | null;
 
@@ -629,43 +630,7 @@
       {:else if selectedDerivationGroup !== undefined}
         {#if selectedDerivationGroupSources.length > 0}
           {#each selectedDerivationGroupSources as source}
-            <!-- Collapsible details -->
-            <Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
-              <svelte:fragment slot="right">
-                <p class="st-typography-body derived-event-count">
-                  {selectedDerivationGroup.sources.get(source.key)?.event_counts} events
-                </p>
-              </svelte:fragment>
-              <div class="st-typography-body">
-                <div class="st-typography-bold">Key:</div>
-                {source.key}
-              </div>
-
-              <div class="st-typography-body">
-                <div class="st-typography-bold">Source Type:</div>
-                {source.source_type_name}
-              </div>
-
-              <div class="st-typography-body">
-                <div class="st-typography-bold">Start Time:</div>
-                {source.start_time}
-              </div>
-
-              <div class="st-typography-body">
-                <div class="st-typography-bold">End Time:</div>
-                {source.end_time}
-              </div>
-
-              <div class="st-typography-body">
-                <div class="st-typography-bold">Valid At:</div>
-                {source.valid_at}
-              </div>
-
-              <div class="st-typography-body">
-                <div class="st-typography-bold">Created At:</div>
-                {source.created_at}
-              </div>
-            </Collapse>
+            <ExternalSourceDetails {source} {user} />
           {/each}
         {:else}
           <p class="st-typography-body">No sources in this group.</p>

--- a/src/components/external-source/ExternalTypeManager.svelte
+++ b/src/components/external-source/ExternalTypeManager.svelte
@@ -629,7 +629,7 @@
         </div>
       {:else if selectedDerivationGroup !== undefined}
         {#if selectedDerivationGroupSources.length > 0}
-          {#each selectedDerivationGroupSources as source}
+          {#each selectedDerivationGroupSources as source (source.key)}
             <ExternalSourceDetails {source} {user} />
           {/each}
         {:else}

--- a/src/components/external-source/ExternalTypeManager.svelte
+++ b/src/components/external-source/ExternalTypeManager.svelte
@@ -656,7 +656,7 @@
 
               <Collapse defaultExpanded={false} title="Sources" tooltipContent="View Contained External Sources">
                 {#each associatedDerivationGroup.sources as source}
-                  <i class="st-typography-body">{source[0]}</i>
+                  <i class="st-typography-body">{source}</i>
                 {/each}
               </Collapse>
             </Collapse>

--- a/src/components/external-source/ExternalTypeManager.svelte
+++ b/src/components/external-source/ExternalTypeManager.svelte
@@ -265,7 +265,7 @@
       headerName: 'Associated External Sources',
       sortable: true,
       valueFormatter: params => {
-        return params?.value.size;
+        return params?.value.length;
       },
       width: 250,
     },

--- a/src/components/modals/DeleteDerivationGroupModal.svelte
+++ b/src/components/modals/DeleteDerivationGroupModal.svelte
@@ -16,7 +16,7 @@
 
   $: derivationGroupsAreAllEmpty = derivationGroups.reduce(
     (isEmptyAcc: boolean, currentDerivationGroup: DerivationGroup) => {
-      return isEmptyAcc && currentDerivationGroup.sources.size === 0;
+      return isEmptyAcc && currentDerivationGroup.sources.length === 0;
     },
     true,
   );

--- a/src/components/modals/DeleteDerivationGroupModal.svelte
+++ b/src/components/modals/DeleteDerivationGroupModal.svelte
@@ -54,7 +54,7 @@
             {#each derivationGroup.sources as source}
               <ul class="modal-content-text">
                 <li>
-                  {source[0]}
+                  {source}
                 </li>
               </ul>
             {/each}

--- a/src/components/modals/ManagePlanDerivationGroupsModal.svelte
+++ b/src/components/modals/ManagePlanDerivationGroupsModal.svelte
@@ -7,7 +7,6 @@
   import ExternalSourceIcon from '../../assets/external-source-box.svg?component';
   import { derivationGroups, externalSources, selectedPlanDerivationGroupNames } from '../../stores/external-source';
   import { plan } from '../../stores/plan';
-  import { plugins } from '../../stores/plugins';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
   import type { DerivationGroup, ExternalSourceSlim } from '../../types/external-source';
@@ -15,8 +14,7 @@
   import { getDerivationGroupRowId } from '../../utilities/externalEvents';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { formatDate } from '../../utilities/time';
-  import Collapse from '../Collapse.svelte';
+  import ExternalSourceDetails from '../external-source/ExternalSourceDetails.svelte';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -267,43 +265,7 @@
           <svelte:fragment slot="body">
             {#if selectedDerivationGroupSources.length > 0}
               {#each selectedDerivationGroupSources as source}
-                <!-- Collapsible details -->
-                <Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
-                  <svelte:fragment slot="right">
-                    <p class="st-typography-body derived-event-count">
-                      {selectedDerivationGroup.sources.get(source.key)?.event_counts} events
-                    </p>
-                  </svelte:fragment>
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">Key:</div>
-                    {source.key}
-                  </div>
-
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">Source Type:</div>
-                    {source.source_type_name}
-                  </div>
-
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">Start Time:</div>
-                    {formatDate(new Date(source.start_time), $plugins.time.primary.format)}
-                  </div>
-
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">End Time:</div>
-                    {formatDate(new Date(source.end_time), $plugins.time.primary.format)}
-                  </div>
-
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">Valid At:</div>
-                    {formatDate(new Date(source.valid_at), $plugins.time.primary.format)}
-                  </div>
-
-                  <div class="st-typography-body">
-                    <div class="st-typography-bold">Created At:</div>
-                    {formatDate(new Date(source.created_at), $plugins.time.primary.format)}
-                  </div>
-                </Collapse>
+                <ExternalSourceDetails {source} {user} />
               {/each}
             {:else}
               <p class="st-typography-body">No sources in this group.</p>
@@ -356,10 +318,6 @@
     height: 100%;
     padding: 0 1rem 0.5rem;
     width: 100%;
-  }
-
-  .derived-event-count {
-    color: var(--st-gray-60);
   }
 
   .new-external-source-button {

--- a/src/components/modals/ManagePlanDerivationGroupsModal.svelte
+++ b/src/components/modals/ManagePlanDerivationGroupsModal.svelte
@@ -264,7 +264,7 @@
           </svelte:fragment>
           <svelte:fragment slot="body">
             {#if selectedDerivationGroupSources.length > 0}
-              {#each selectedDerivationGroupSources as source}
+              {#each selectedDerivationGroupSources as source (source.key)}
                 <ExternalSourceDetails {source} {user} />
               {/each}
             {:else}

--- a/src/components/model/DGModelSpecification.svelte
+++ b/src/components/model/DGModelSpecification.svelte
@@ -5,14 +5,12 @@
   import type { CellEditingStoppedEvent, ValueGetterParams } from 'ag-grid-community';
   import ExternalSourceIcon from '../../assets/external-source-box.svg?component';
   import { derivationGroups, externalSources } from '../../stores/external-source';
-  import { plugins } from '../../stores/plugins';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
   import type { DerivationGroup, ExternalSourceSlim } from '../../types/external-source';
   import { getDerivationGroupRowId } from '../../utilities/externalEvents';
   import { featurePermissions } from '../../utilities/permissions';
-  import { formatDate } from '../../utilities/time';
-  import Collapse from '../Collapse.svelte';
+  import ExternalSourceDetails from '../external-source/ExternalSourceDetails.svelte';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -186,43 +184,7 @@
     <svelte:fragment slot="body">
       {#if selectedDerivationGroupSources.length > 0}
         {#each selectedDerivationGroupSources as source}
-          <!-- Collapsible details -->
-          <Collapse title={source.key} tooltipContent={source.key} defaultExpanded={false}>
-            <svelte:fragment slot="right">
-              <p class="st-typography-body derived-event-count">
-                {selectedDerivationGroup?.sources.get(source.key)?.event_counts} events
-              </p>
-            </svelte:fragment>
-            <div class="st-typography-body">
-              <div class="st-typography-bold">Key:</div>
-              {source.key}
-            </div>
-
-            <div class="st-typography-body">
-              <div class="st-typography-bold">Source Type:</div>
-              {source.source_type_name}
-            </div>
-
-            <div class="st-typography-body">
-              <div class="st-typography-bold">Start Time:</div>
-              {formatDate(new Date(source.start_time), $plugins.time.primary.format)}
-            </div>
-
-            <div class="st-typography-body">
-              <div class="st-typography-bold">End Time:</div>
-              {formatDate(new Date(source.end_time), $plugins.time.primary.format)}
-            </div>
-
-            <div class="st-typography-body">
-              <div class="st-typography-bold">Valid At:</div>
-              {formatDate(new Date(source.valid_at), $plugins.time.primary.format)}
-            </div>
-
-            <div class="st-typography-body">
-              <div class="st-typography-bold">Created At:</div>
-              {formatDate(new Date(source.created_at), $plugins.time.primary.format)}
-            </div>
-          </Collapse>
+          <ExternalSourceDetails {source} {user} />
         {/each}
       {:else}
         <p class="st-typography-body">
@@ -257,10 +219,6 @@
 
   .derivation-groups-modal-table-container {
     padding: 0 1rem 0.5rem;
-  }
-
-  .derived-event-count {
-    color: var(--st-gray-60);
   }
 
   .new-external-source-button {

--- a/src/components/model/DGModelSpecification.svelte
+++ b/src/components/model/DGModelSpecification.svelte
@@ -183,7 +183,7 @@
     </svelte:fragment>
     <svelte:fragment slot="body">
       {#if selectedDerivationGroupSources.length > 0}
-        {#each selectedDerivationGroupSources as source}
+        {#each selectedDerivationGroupSources as source (source.key)}
           <ExternalSourceDetails {source} {user} />
         {/each}
       {:else}

--- a/src/stores/external-source.ts
+++ b/src/stores/external-source.ts
@@ -112,11 +112,6 @@ function transformDerivationGroups(
           };
         };
         external_sources: {
-          external_events_aggregate: {
-            aggregate: {
-              count: number;
-            };
-          };
           key: string;
         }[];
         name: string;
@@ -134,16 +129,7 @@ function transformDerivationGroups(
         name: derivationGroup.name,
         owner: derivationGroup.owner,
         source_type_name: derivationGroup.source_type_name,
-        sources: new Map(
-          derivationGroup.external_sources.reduce(
-            (accumulatedSources, currentSource) => {
-              const source_key = currentSource.key;
-              const event_counts = currentSource.external_events_aggregate.aggregate.count;
-              return [...accumulatedSources, [source_key, { event_counts }] as [string, { event_counts: number }]];
-            },
-            <[string, { event_counts: number }][]>[],
-          ),
-        ),
+        sources: derivationGroup.external_sources.map(externalSource => externalSource.key),
       });
     });
   }

--- a/src/types/external-source.ts
+++ b/src/types/external-source.ts
@@ -80,7 +80,7 @@ export type DerivationGroup = {
   name: string;
   owner: UserId;
   source_type_name: string;
-  sources: Map<string, { event_counts: number }>;
+  sources: string[];
 };
 
 export type ExternalSourceInsertInput = {
@@ -94,3 +94,11 @@ export type DerivationGroupInsertInput = Pick<DerivationGroup, 'name' | 'source_
 
 // Used to track whether a newly added source has been acknowledged or not for a given plan
 export type DerivationGroupUpdateAckEntry = { derivation_group: string; last_acknowledged_at: string };
+
+export type ExternalSourceExternalEventCountResponse = {
+  external_events_aggregate: {
+    aggregate: {
+      count: number;
+    };
+  };
+};

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4534,7 +4534,7 @@ const effects = {
     }
   },
 
-  async getExternalSourceEventCount(externalSource: ExternalSourceSlim, user: User | null): Promise<number> {
+  async getExternalSourceEventCount(externalSource: ExternalSourceSlim, user: User | null): Promise<number | null> {
     try {
       const data = await reqHasura<ExternalSourceExternalEventCountResponse>(
         gql.GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNT,
@@ -4552,7 +4552,7 @@ const effects = {
       }
     } catch (e) {
       catchError('log', `Failed to get external events for external source: ${externalSource.key}`, e as Error);
-      return 0;
+      return null;
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4552,7 +4552,6 @@ const effects = {
       }
     } catch (e) {
       catchError('log', `Failed to get external events for external source: ${externalSource.key}`, e as Error);
-      showFailureToast('Failed to get external source event count');
       return 0;
     }
   },

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -121,6 +121,7 @@ import type { ExternalEvent, ExternalEventDB, ExternalEventType } from '../types
 import type {
   DerivationGroup,
   DerivationGroupInsertInput,
+  ExternalSourceExternalEventCountResponse,
   ExternalSourcePkey,
   ExternalSourceSlim,
   ModelDerivationGroup,
@@ -4530,6 +4531,29 @@ const effects = {
         error,
       );
       throw error;
+    }
+  },
+
+  async getExternalSourceEventCount(externalSource: ExternalSourceSlim, user: User | null): Promise<number> {
+    try {
+      const data = await reqHasura<ExternalSourceExternalEventCountResponse>(
+        gql.GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNT,
+        {
+          derivationGroupName: externalSource.derivation_group_name,
+          externalSourceKey: externalSource.key,
+        },
+        user,
+      );
+      const externalSourceCount = data.external_source_by_pk?.external_events_aggregate.aggregate.count;
+      if (externalSourceCount) {
+        return externalSourceCount;
+      } else {
+        return 0;
+      }
+    } catch (e) {
+      catchError('log', `Failed to get external events for external source: ${externalSource.key}`, e as Error);
+      showFailureToast('Failed to get external source event count');
+      return 0;
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4545,7 +4545,7 @@ const effects = {
         user,
       );
       const externalSourceCount = data.external_source_by_pk?.external_events_aggregate.aggregate.count;
-      if (externalSourceCount) {
+      if (externalSourceCount !== undefined) {
         return externalSourceCount;
       } else {
         return 0;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1261,6 +1261,18 @@ const gql = {
     }
   `,
 
+  GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNT: `#graphql
+    query GetExternalSourceExternalEventCount($externalSourceKey: String!, $derivationGroupName: String!) {
+      external_source_by_pk(derivation_group_name: $derivationGroupName, key: $externalSourceKey) {
+        external_events_aggregate {
+          aggregate {
+            count
+          }
+        }
+      }
+    }
+  `,
+
   GET_MODELS: `#graphql
     query GetModels {
       models: ${Queries.MISSION_MODELS} {
@@ -2366,11 +2378,6 @@ const gql = {
         }
         external_sources {
           key
-          external_events_aggregate {
-            aggregate {
-              count
-            }
-          }
         }
       }
     }

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -777,8 +777,9 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     return isUserAdmin(user) || getPermission([Queries.SEQUENCE_TO_SIMULATED_ACTIVITY], user);
   },
   GET_EXTERNAL_EVENTS: () => true,
-  GET_EXTERNAL_EVENT_TYPE_BY_SOURCE: () => true,
+  GET_EXTERNAL_EVENT_TYPE_BY_SOURCE: user => queryPermissions.SUB_DERIVATION_GROUPS(user),
   GET_EXTERNAL_PROFILE_SEGMENTS_SINCE: () => true,
+  GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNT: () => true,
   GET_MODELS: () => true,
   GET_PARCEL: () => true,
   GET_PARSED_CHANNEL_DICTIONARY: () => true,


### PR DESCRIPTION
This PR modifies the derivation group subscription to remove the external event count lookups. The change removes the aggregation count from the main Hasura subscription and adds it as a standalone query, `GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNTS`.

In our LRO deployment, we have been collecting live external event data for multiple months. These in total make up approx. 1 million external events across ~1,200 external sources. At this size, the subscription is very slow to complete and will hold up the UI. This is most notable in the 'Manage Derivation Group' modal in the plan view which will show 'No Derivation Groups' for an extended period of time while the subscription retrieves the source information. With some rough estimates using our data set, the current subscription takes approx. 90 seconds. With the change, the derivation group subscription takes approx. 3 seconds.

The event count can still be a helpful tool so to cover that this PR adds a new query, `GET_EXTERNAL_SOURCE_EXTERNAL_EVENT_COUNTS` which is called in the new component `ExternalSourceDetails.svelte` to gather the counts for the specific external source the component is created for. This component fulfills the same role as some prior code that was copy/pasted between the places the derivation group information was used.

## Testing
1. Upload at least 1 external source + external event schema
2. Upload at least 1 external source that uses the uploaded source + event schemas
3. Create a plan
4. Open the `External Sources` panel and click `Manage Derivation Groups`
5. Derivation groups should be show - this should be performant now even with lots of external events
6. Hover over a derivation group and click the 'View' button
7. Event counts should be shown next to the sources in the derivation group

Note there is some e2e test changes included as the common component now enforces a time format that doesn't match how some of these components formatted times previously.