### PR TITLE
Only open new page if extension provides `url`

### DIFF
--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -18,7 +18,7 @@ export type ExtensionPayload = {
 export type ExtensionResponse = {
   message: string;
   success: boolean;
-  url: string;
+  url?: string;
 };
 
 export type ExtensionRole = {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -672,7 +672,9 @@ const effects = {
       if (response.success) {
         showSuccessToast(response.message);
         logMessage('log', `Executed extension "${extension.label}" (ID=${extension.id}).`);
-        window.open(response.url, '_blank');
+        if (response.url) {
+          window.open(response.url, '_blank');
+        }
       } else {
         throw new Error(response.message);
       }


### PR DESCRIPTION
This PR updates `callExtension` to only attempt to open a new window if the extension's response had a non-empty `url` parameter. Currently as written, a new tab is opened on success regardless of what is sent in the response.

`ExtensionResponse` is also updated to reflect `url` as an optional parameter in the response.

Based on the documentation, I think this is already how the feature is *supposed* to function. [For reference](https://nasa-ammos.github.io/plandev-docs/planning/advanced-extensions/)