### PR TITLE
Create metadata on push to sequence workspace

### DIFF
--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -7,6 +7,7 @@
   import TrashIcon from '@nasa-jpl/stellar/icons/trash.svg?component';
   import { Download, FileCode2, SquareCode } from 'lucide-svelte';
   import { expansionSequences, filteredExpansionSequences } from '../../stores/expansion';
+  import { selectedPlanDerivationGroupNames } from '../../stores/external-source';
   import { plan } from '../../stores/plan';
   import { expandedTemplates } from '../../stores/sequence-template';
   import { sequenceFilters } from '../../stores/sequencing';
@@ -16,6 +17,7 @@
   import type { ActivityLayerFilter } from '../../types/timeline';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
+  import { getExpandedTemplateForSequence } from '../../utilities/expansion';
   import { downloadBlob } from '../../utilities/generic';
   import { showExpansionSequenceModal, showNewSequenceModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -26,7 +28,6 @@
   import ActivityFilterBuilder from '../timeline/form/TimelineEditor/ActivityFilterBuilder.svelte';
   import ListItem from '../ui/ListItem.svelte';
   import Panel from '../ui/Panel.svelte';
-  import { getExpandedTemplateForSequence } from '../../utilities/expansion';
 
   export let gridSection: ViewGridSection;
   export let user: User | null;
@@ -157,8 +158,23 @@
   async function onSendExpandedSequenceToWorkspace(sequence: ExpansionSequence) {
     const expandedTemplate = getExpandedTemplateForSequence($expandedTemplates, sequence);
     const expandedResult = expandedTemplate?.expanded_template ?? `No output found for sequence "${sequence.seq_id}"`;
-
-    await effects.sendSequenceToWorkspace(sequence, expandedResult, user);
+    const newFileMetadata = {
+      user: {
+        model: {
+          id: $plan?.model_id ?? -1,
+          name: $plan?.model?.name ?? '',
+        },
+        plan: {
+          derivationGroups: $selectedPlanDerivationGroupNames,
+          end: $plan?.end_time_doy ?? '',
+          name: $plan?.name ?? '',
+          start: $plan?.start_time_doy ?? '',
+        },
+        sequence_metadata: sequence.metadata,
+        simulation_dataset_id: sequence.simulation_dataset_id,
+      },
+    };
+    await effects.sendSequenceToWorkspace(sequence, expandedResult, newFileMetadata, user);
   }
 
   function onShowExpandedSequence(sequence: ExpansionSequence) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -238,7 +238,12 @@ import type { ActivityTransformDirection } from '../types/time';
 import type { ActivityLayerFilter, Layer, Row, Timeline } from '../types/timeline';
 import type { View, ViewDefinition, ViewInsertInput, ViewSlim, ViewUpdateInput } from '../types/view';
 import type { Workspace, WorkspaceCollaborator } from '../types/workspace';
-import type { WorkspaceTreeMap, WorkspaceTreeNode, WorkspaceTreeNodeWithFullPath } from '../types/workspace-tree-view';
+import type {
+  WorkspaceFileMetadata,
+  WorkspaceTreeMap,
+  WorkspaceTreeNode,
+  WorkspaceTreeNodeWithFullPath,
+} from '../types/workspace-tree-view';
 import {
   ActivityDeletionAction,
   addAbsoluteTimeToRevision,
@@ -6990,6 +6995,7 @@ const effects = {
   async sendSequenceToWorkspace(
     sequence: ExpansionSequence | null,
     expandedSequence: string | null,
+    metadata: Partial<Pick<WorkspaceFileMetadata, 'readOnly' | 'user'>>,
     user: User | null,
   ): Promise<string | null> {
     try {
@@ -7033,6 +7039,7 @@ const effects = {
       if (confirmNewFile && confirmNewFileValue) {
         const { filePath: newFilePath } = confirmNewFileValue;
         await WorkspaceApi.saveFile(workspaceId, newFilePath, expandedSequence, false, user);
+        await WorkspaceApi.setFileMetadata(workspaceId, newFilePath, metadata, user);
 
         showSuccessToast('Workspace File Created Successfully');
       } else {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6995,7 +6995,7 @@ const effects = {
   async sendSequenceToWorkspace(
     sequence: ExpansionSequence | null,
     expandedSequence: string | null,
-    metadata: Partial<Pick<WorkspaceFileMetadata, 'readOnly' | 'user'>>,
+    metadata: Partial<Pick<WorkspaceFileMetadata, 'user'>>,
     user: User | null,
   ): Promise<string | null> {
     try {


### PR DESCRIPTION
This PR enhances the 'Send to Workspace' feature for sequences to also include a metadata file with them that has information on the plan, model, and simulation that were used to 'generate' the sequence.

This was requested by the LRO team in order to provide them more information on the sequences they are generating, and to power a report-generation action they use.