### PR TITLE
Alias aerie_admin -> admin in user dropdown

### DIFF
--- a/e2e-tests/fixtures/User.ts
+++ b/e2e-tests/fixtures/User.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 import { adjectives, names, uniqueNamesGenerator } from 'unique-names-generator';
+import { getRoleDisplayName } from '../../src/utilities/roles.js';
 import { AppNav } from './AppNav.js';
 
 export async function performLogin(page: Page, baseURL?: string, username: string = 'test') {
@@ -71,10 +72,12 @@ export class User {
   }
 
   async switchRole(role: string = 'aerie_admin') {
+    // The dropdown shows display aliases (e.g. aerie_admin renders as "admin").
+    const roleLabel = getRoleDisplayName(role);
     await this.page.getByRole('navigation').getByRole('combobox').click();
-    await this.page.getByRole('listbox').getByRole('option', { name: role }).click();
+    await this.page.getByRole('listbox').getByRole('option', { exact: true, name: roleLabel }).click();
     // Wait for success toast confirming the role change completed
     await expect(this.page.getByText('Changed Role Successfully')).toBeVisible();
-    await expect(this.page.getByRole('navigation').getByRole('combobox')).toHaveText(role);
+    await expect(this.page.getByRole('navigation').getByRole('combobox')).toHaveText(roleLabel);
   }
 }

--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -4,6 +4,7 @@
   import type { Writable } from 'svelte/store';
   import type { User, UserRole } from '../../types/app';
   import { changeUserRole } from '../../utilities/permissions';
+  import { getRoleDisplayName } from '../../utilities/roles';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
   import AppMenu from '../menus/AppMenu.svelte';
 
@@ -39,7 +40,7 @@
     <slot name="right" />
     {#if userRoles.length > 1}
       <Select.Root
-        selected={{ label: $user?.activeRole ?? '', value: $user?.activeRole ?? '' }}
+        selected={{ label: getRoleDisplayName($user?.activeRole), value: $user?.activeRole ?? '' }}
         onSelectedChange={v => v && changeRole(v.value)}
         loop={false}
       >
@@ -49,7 +50,9 @@
         <Select.Content>
           <Select.Label size="xs">Select Role</Select.Label>
           {#each userRoles as userRole}
-            <Select.Item size="xs" value={userRole} label={userRole}>{userRole}</Select.Item>
+            <Select.Item size="xs" value={userRole} label={getRoleDisplayName(userRole)}>
+              {getRoleDisplayName(userRole)}
+            </Select.Item>
           {/each}
         </Select.Content>
         <Select.Input name="user-menu" aria-label="Select Role hidden input" />

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -11,7 +11,7 @@ import type {
   PlanMergeRequestSchema,
 } from '../../types/plan';
 import effects from '../../utilities/effects';
-import { ADMIN_ROLE } from '../../utilities/permissions';
+import { ADMIN_ROLE } from '../../utilities/roles';
 import PlanMergeReview from './PlanMergeReview.svelte';
 
 vi.mock('svelte', async importOriginal => {

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, render } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ADMIN_ROLE } from '../../../utilities/permissions';
+import { ADMIN_ROLE } from '../../../utilities/roles';
 import SchedulingGoalForm from './SchedulingGoalForm.svelte';
 
 vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -2,7 +2,7 @@ import { goto } from '$app/navigation';
 import { env } from '$env/dynamic/public';
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { logout, shouldRedirectToLogin } from './login';
-import { ADMIN_ROLE } from './permissions';
+import { ADMIN_ROLE } from './roles';
 
 // $app/* and $env/* are virtual modules provided by the SvelteKit Vite plugin. Mock them so
 // `logout()` runs in the browser branch with a controllable SSO flag and a spyable navigation.

--- a/src/utilities/permissions.test.ts
+++ b/src/utilities/permissions.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest';
 import {
-  ADMIN_ROLE,
   hasNoAuthorization,
   isAdminRole,
   isPlanCollaborator,
@@ -8,6 +7,7 @@ import {
   isUserAdmin,
   isUserOwner,
 } from './permissions';
+import { ADMIN_ROLE } from './roles';
 
 describe('hasNoAuthorization', () => {
   test('Should return whether or not the user has authorization', () => {

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -35,10 +35,10 @@ import type { View, ViewSlim } from '../types/view';
 import type { Workspace } from '../types/workspace';
 import type { WorkspaceTreeNode } from '../types/workspace-tree-view';
 import gql from './gql';
+import { ADMIN_ROLE } from './roles';
 import { showFailureToast } from './toast';
 import type { WorkspaceApi } from './workspaces';
 
-export const ADMIN_ROLE = 'aerie_admin';
 export const VIEWER_ROLE = 'viewer';
 
 export const INVALID_JWT = 'invalid-jwt';

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -35,11 +35,9 @@ import type { View, ViewSlim } from '../types/view';
 import type { Workspace } from '../types/workspace';
 import type { WorkspaceTreeNode } from '../types/workspace-tree-view';
 import gql from './gql';
-import { ADMIN_ROLE } from './roles';
+import { ADMIN_ROLE, VIEWER_ROLE } from './roles';
 import { showFailureToast } from './toast';
 import type { WorkspaceApi } from './workspaces';
-
-export const VIEWER_ROLE = 'viewer';
 
 export const INVALID_JWT = 'invalid-jwt';
 export const EXPIRED_JWT = 'JWTExpired';

--- a/src/utilities/roles.test.ts
+++ b/src/utilities/roles.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { ADMIN_ROLE, getRoleDisplayName } from './roles';
+
+describe('roles util', () => {
+  describe('getRoleDisplayName', () => {
+    test('should alias the admin role', () => {
+      expect(getRoleDisplayName(ADMIN_ROLE)).toEqual('admin');
+    });
+
+    test('should pass through roles without an alias', () => {
+      expect(getRoleDisplayName('user')).toEqual('user');
+      expect(getRoleDisplayName('viewer')).toEqual('viewer');
+    });
+
+    test('should return an empty string for an absent role', () => {
+      expect(getRoleDisplayName(null)).toEqual('');
+      expect(getRoleDisplayName(undefined)).toEqual('');
+      expect(getRoleDisplayName('')).toEqual('');
+    });
+  });
+});

--- a/src/utilities/roles.ts
+++ b/src/utilities/roles.ts
@@ -1,0 +1,26 @@
+import type { UserRole } from '../types/app';
+
+export const ADMIN_ROLE = 'aerie_admin';
+
+/**
+ * Display-only aliases for role names.
+ *
+ * When Aerie was rebranded to PlanDev the `aerie_admin` Hasura role was left in place, since
+ * renaming it would be a breaking change for every deployment's database and permission config.
+ * This map hides that legacy name from the UI without touching it anywhere it actually matters:
+ * the values sent to the backend (`x-hasura-role`, the `activeRole` cookie, permission checks)
+ * are always the real role. If the role is ever renamed in the database, delete its entry here.
+ */
+const ROLE_DISPLAY_NAMES: Record<string, string> = {
+  [ADMIN_ROLE]: 'admin',
+};
+
+/**
+ * Returns the label to show a user for a role. Roles without an alias are shown as-is.
+ */
+export function getRoleDisplayName(userRole?: UserRole | null): string {
+  if (!userRole) {
+    return '';
+  }
+  return ROLE_DISPLAY_NAMES[userRole] ?? userRole;
+}

--- a/src/utilities/roles.ts
+++ b/src/utilities/roles.ts
@@ -1,6 +1,7 @@
 import type { UserRole } from '../types/app';
 
 export const ADMIN_ROLE = 'aerie_admin';
+export const VIEWER_ROLE = 'viewer';
 
 /**
  * Display-only aliases for role names.


### PR DESCRIPTION
Hide "aerie_admin" from users in UI, actual value is preserved elsewhere.