### PR TITLE
Fix default view save button not disabling bug for admins

### DIFF
--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -39,14 +39,16 @@
     uploadView: void;
   }>();
 
+  let isDefaultView: boolean = false;
+  let bottomPanelIsOn: boolean = false;
   let leftPanelIsOn: boolean = false;
   let leftSplitPanelIsOn: boolean = false;
-  let bottomPanelIsOn: boolean = false;
   let rightPanelIsOn: boolean = false;
   let rightSplitPanelIsOn: boolean = false;
   let saveViewDisabled: boolean = true;
 
-  $: saveViewDisabled = $view?.name === '' || !hasUpdatePermission || !$viewIsModified;
+  $: isDefaultView = $view?.id === -1;
+  $: saveViewDisabled = isDefaultView || $view?.name === '' || !hasUpdatePermission || !$viewIsModified;
   $: if ($view?.definition.plan.grid) {
     leftPanelIsOn = !$view.definition.plan.grid.leftHidden && !$view.definition.plan.grid.leftSplit;
     leftSplitPanelIsOn = !$view.definition.plan.grid.leftHidden && $view.definition.plan.grid.leftSplit;
@@ -161,7 +163,7 @@
       >
         Save as
       </MenuItem>
-      {#if $view?.name && $view.name !== defaultViewName}
+      {#if $view?.name && !isDefaultView}
         <MenuItem disabled={!$viewIsModified} on:click={resetView}>Reset to last saved</MenuItem>
       {/if}
       <MenuItem on:click={resetViewToDefault}>Reset to default</MenuItem>
@@ -189,7 +191,7 @@
         Download view
       </MenuItem>
       <MenuItem on:click={() => showSavedViewsModal(user)}>Browse saved views</MenuItem>
-      {#if $view?.name && $view.name !== defaultViewName}
+      {#if $view?.name && !isDefaultView}
         <hr />
         <MenuItem
           on:click={editView}

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -384,7 +384,7 @@ export function generateDefaultView(
       },
       version: viewSchemaVersion,
     },
-    id: 0,
+    id: -1, // Sentinel value for checking default view identity, never persisted to db
     name: 'Default View',
     owner: 'system',
     updated_at: now,


### PR DESCRIPTION
Closes #1966 - see that issue for repro instructions. Changes ID of default view generated client side to be -1 and check that in ViewMenu to determine if a view is default. This default view ID is not sent to the DB so is purely a placeholder/sentinel value.